### PR TITLE
fix: add whitespace between 2 paragraphs

### DIFF
--- a/module-2/README.md
+++ b/module-2/README.md
@@ -1,6 +1,7 @@
 # Module 2
 
 Second module created for testing
+
 Segundo módulo creado para pruebas.
 
 Versions:


### PR DESCRIPTION
Looks like the PR title does need a semver prefix if it's being squashed. Something we need to enforce somehow.